### PR TITLE
Remove deprecated functions for 1.0 release

### DIFF
--- a/openpolicedata/__init__.py
+++ b/openpolicedata/__init__.py
@@ -4,4 +4,3 @@ from . import defs
 from .import datasets
 from .defs import TableType
 from .defs import columns as Column
-from .deprecated.datasetsCompat import datasets_query

--- a/openpolicedata/data.py
+++ b/openpolicedata/data.py
@@ -1000,26 +1000,6 @@ class Source:
             yield self.__load(table_type, year, agency, True, pbar, nrows=min(nbatch, count-k), offset=k, 
                               verbose=verbose, url_contains=url, id=id, format_date=format_date, sortby=sortby)
     
-    @deprecated("load_from_url_gen is deprecated and will be removed in a future release. Please use load_iter instead. "+
-                "load_iter uses the same inputs except table_type now comes before year.")
-    def load_from_url_gen(self, 
-                          year: str | int | list[int], 
-                          table_type: str | defs.TableType | None = None, 
-                          agency: str | None = None, 
-                          pbar: bool = False, 
-                          nbatch: int = 10000, 
-                          offset: int = 0, 
-                          force: bool =False,
-                          verbose: bool | str | int = False
-                          ) -> Iterator[Table]:
-        '''load_from_url_gen is deprecated. Please use load_iter instead.
-        '''
-
-        count = self.get_count(table_type, year, agency, force, verbose=verbose)
-        for k in range(offset, count, nbatch):
-            yield self.__load(table_type, year, agency, True, pbar, nrows=min(nbatch, count-k), offset=k, verbose=verbose)
-
-    
     @input_swap([1,2], ['table_type','year'], [defs.TableType, {'values':[defs.NA, defs.MULTI], 'types':[list, int]}], error=True, opt1=None)
     def load(self, 
             table_type: str | defs.TableType, 
@@ -1082,23 +1062,6 @@ class Source:
                            verbose=verbose, url_contains=url, id=id, format_date=format_date)
 
     
-    @deprecated("load_from_url is deprecated and will be removed in a future release. Please use load instead. "+
-                "load uses the same inputs except table_type now comes before year.")
-    def load_from_url(self, 
-                      year: str | int | list[int], 
-                      table_type: str | defs.TableType | None = None, 
-                      agency: str | None = None,
-                      pbar: bool = True,
-                      nrows: int | None = None, 
-                      offset: int = 0,
-                      sortby=None,
-                      verbose: bool | str | int = False
-                      ) -> Table:
-        '''load_from_url is deprecated and will be removed in a future release. Please use load instead.
-        '''
-
-        return self.__load(table_type, year, agency, True, pbar, nrows=nrows, offset=offset, sortby=sortby, verbose=verbose)
-
     def __find_datasets(self, table_type, src=None):
         if src is None:
             src = self.datasets.copy()

--- a/openpolicedata/deprecated/datasetsCompat.py
+++ b/openpolicedata/deprecated/datasetsCompat.py
@@ -1,8 +1,0 @@
-from ..datasets import query as _query
-from ._decorators import deprecated
-
-# For back compatibility, preferred usage is datasets.query
-@deprecated("opd.datasets_query is deprecated and will be removed in a future version. "
-        "Please use opd.datasets.query instead.")
-def datasets_query(source_name=None, state=None, agency=None, table_type=None):
-    return _query(source_name=source_name, state=state, agency=agency, table_type=table_type)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -8,7 +8,6 @@ import warnings
 import openpolicedata as opd
 from openpolicedata.defs import TableType
 from openpolicedata.deprecated._decorators import deprecated, input_swap
-from openpolicedata.deprecated.datasetsCompat import datasets_query
 from openpolicedata.deprecated._pandas import DeprecationHandlerDataFrame, DeprecationHandlerSeries
 import pytest
 
@@ -77,12 +76,6 @@ def test_inputswap_class_error(year, table_type):
 @deprecated("MSG")
 def fdep():
 	pass
-
-@pytest.mark.parametrize("func", [fdep, datasets_query])
-def test_deprecated_decorator(func):
-	with pytest.deprecated_call():
-		func()
-
 
 @pytest.mark.parametrize("type1, type2", [("COMPLAINTS - SUBJECTS", 'COMPLAINTS - CIVILIANS'),
 										  ("USE OF FORCE - SUBJECTS/OFFICERS", 'USE OF FORCE - CIVILIANS/OFFICERS')])


### PR DESCRIPTION
This PR removes the following functions and associated usages:

- `datasets_query`
- `load_from_url`
- `load_from_url_gen`

I tried to test these changes but it looks like the suite relies on some data; if a maintainer could take a quick look to confirm this looks good that would be great!