### PR TITLE
Remove method from TableType & deprecation messages

### DIFF
--- a/openpolicedata/datasets.py
+++ b/openpolicedata/datasets.py
@@ -7,7 +7,7 @@ import warnings
 
 from . import defs, dataset_id
 from .deprecated._pandas import DeprecationHandlerDataFrame
-from .deprecated.messages import CIV_DEPRECATION_MESSAGE, CIV_REPLACEMENT_MESSAGE
+from .deprecated.messages import CIV_REPLACEMENT_MESSAGE
 from .deprecated.source_table_compat import check_compat_source_table
 
 # Location of table where datasets available in opd are stored
@@ -143,7 +143,7 @@ def query(
     if table_type != None:
         if "CIVILIAN" in str(table_type):
             new_table_type = str(table_type).replace("CIVILIAN", "SUBJECT")
-            warnings.warn(CIV_DEPRECATION_MESSAGE + CIV_REPLACEMENT_MESSAGE.format(table_type, new_table_type),
+            warnings.warn(CIV_REPLACEMENT_MESSAGE.format(table_type, new_table_type),
                             DeprecationWarning)
             table_type = new_table_type
         query_str += "TableType == '" + table_type + "' and "
@@ -316,7 +316,7 @@ def get_table_types(contains=None):
     if contains is not None:
         if "CIVILIAN" in contains:
             new_contains = str(contains).replace("CIVILIAN", "SUBJECT")
-            warnings.warn(CIV_DEPRECATION_MESSAGE + CIV_REPLACEMENT_MESSAGE.format(contains, new_contains),
+            warnings.warn(CIV_REPLACEMENT_MESSAGE.format(contains, new_contains),
                             DeprecationWarning)
             contains = new_contains
         table_types = [x for x in table_types if contains.lower() in x.lower()]

--- a/openpolicedata/datasets.py
+++ b/openpolicedata/datasets.py
@@ -7,7 +7,6 @@ import warnings
 
 from . import defs, dataset_id
 from .deprecated._pandas import DeprecationHandlerDataFrame
-from .deprecated.messages import CIV_REPLACEMENT_MESSAGE
 from .deprecated.source_table_compat import check_compat_source_table
 
 # Location of table where datasets available in opd are stored
@@ -141,11 +140,6 @@ def query(
         query_str += "Agency == '" + agency + "' and " 
 
     if table_type != None:
-        if "CIVILIAN" in str(table_type):
-            new_table_type = str(table_type).replace("CIVILIAN", "SUBJECT")
-            warnings.warn(CIV_REPLACEMENT_MESSAGE.format(table_type, new_table_type),
-                            DeprecationWarning)
-            table_type = new_table_type
         query_str += "TableType == '" + table_type + "' and "
 
     if len(query_str) == 0:
@@ -314,11 +308,6 @@ def get_table_types(contains=None):
     df = query()
     table_types = df["TableType"].unique()
     if contains is not None:
-        if "CIVILIAN" in contains:
-            new_contains = str(contains).replace("CIVILIAN", "SUBJECT")
-            warnings.warn(CIV_REPLACEMENT_MESSAGE.format(contains, new_contains),
-                            DeprecationWarning)
-            contains = new_contains
         table_types = [x for x in table_types if contains.lower() in x.lower()]
     table_types.sort()
     return table_types

--- a/openpolicedata/defs.py
+++ b/openpolicedata/defs.py
@@ -40,22 +40,6 @@ class TableType(str, Enum):
     def __str__(self):
         return self.value
     
-    
-    @classmethod
-    def _missing_(cls, value):
-        # https://stackoverflow.com/questions/37444002/overriding-enum-call-method
-        # Handles deprecation of CIVILIANS usage to SUBJECTS
-        if "- CIVILIANS" in value:
-            new_value = value.replace("- CIVILIANS", "- SUBJECTS")
-            if new_value in TableType._value2member_map_:
-                warnings.warn(
-                    f"TableType {value} is deprecated. CIVILIAN has been replaced with SUBJECT in TableType names. Requested TableType has been automatically updated to {new_value}.",
-                    DeprecationWarning,
-                )
-                return TableType(new_value)
-        
-        return super()._missing_(value)
-
     # Below tuples are (value, description)
     ARRESTS = ("ARRESTS", "Seizures or forcible restraints by police")
     CALLS_FOR_SERVICE = ("CALLS FOR SERVICE", "Includes dispatched calls (911 or non-emergency #) and officer-initiated calls")

--- a/openpolicedata/deprecated/_pandas.py
+++ b/openpolicedata/deprecated/_pandas.py
@@ -1,7 +1,7 @@
 import warnings
 from pandas import DataFrame, Series
 from pandas.core.indexing import _iLocIndexer, _LocIndexer
-from .messages import CIV_DEPRECATION_MESSAGE, CIV_REPLACEMENT_MESSAGE
+from .messages import CIV_REPLACEMENT_MESSAGE
 
 def _cast_if_necessary(result):
     if isinstance(result, Series) and result.name == 'TableType' and \
@@ -45,7 +45,7 @@ class DeprecationHandlerSeries(Series):
     def _cmp_method(self, other, op):
         if 'CIVILIAN' in other:
             new_other = other.replace("CIVILIAN","SUBJECT")
-            warnings.warn(CIV_DEPRECATION_MESSAGE + CIV_REPLACEMENT_MESSAGE.format(other, new_other),
+            warnings.warn(CIV_REPLACEMENT_MESSAGE.format(other, new_other),
                             DeprecationWarning,
                             stacklevel=1)
             other = new_other
@@ -56,7 +56,7 @@ class DeprecationHandlerSeries(Series):
     def isin(self, values) -> Series:
         if self.name == 'TableType' and any(["CIVILIAN" in x for x in values]):
             new_values = [x.replace("CIVILIAN","SUBJECT") for x in values]
-            warnings.warn(DeprecationWarning(CIV_DEPRECATION_MESSAGE + CIV_REPLACEMENT_MESSAGE.format(values, new_values)))
+            warnings.warn(DeprecationWarning(CIV_REPLACEMENT_MESSAGE.format(values, new_values)))
             values = new_values
 
         return super().isin(values)       

--- a/openpolicedata/deprecated/_pandas.py
+++ b/openpolicedata/deprecated/_pandas.py
@@ -1,7 +1,6 @@
 import warnings
 from pandas import DataFrame, Series
 from pandas.core.indexing import _iLocIndexer, _LocIndexer
-from .messages import CIV_REPLACEMENT_MESSAGE
 
 def _cast_if_necessary(result):
     if isinstance(result, Series) and result.name == 'TableType' and \
@@ -43,22 +42,10 @@ class _LocIndexerSub(_LocIndexer):
 
 class DeprecationHandlerSeries(Series):
     def _cmp_method(self, other, op):
-        if 'CIVILIAN' in other:
-            new_other = other.replace("CIVILIAN","SUBJECT")
-            warnings.warn(CIV_REPLACEMENT_MESSAGE.format(other, new_other),
-                            DeprecationWarning,
-                            stacklevel=1)
-            other = new_other
-
         return super()._cmp_method(other, op)
  
 
     def isin(self, values) -> Series:
-        if self.name == 'TableType' and any(["CIVILIAN" in x for x in values]):
-            new_values = [x.replace("CIVILIAN","SUBJECT") for x in values]
-            warnings.warn(DeprecationWarning(CIV_REPLACEMENT_MESSAGE.format(values, new_values)))
-            values = new_values
-
         return super().isin(values)       
 
 

--- a/openpolicedata/deprecated/messages.py
+++ b/openpolicedata/deprecated/messages.py
@@ -1,3 +1,0 @@
-CIV_REPLACEMENT_MESSAGE =  "{} is being corrected to {}. "+\
-                    "Please replace 'CIVILIAN' with 'SUBJECT' in your code as this correction will be removed "+\
-                    "in a future release."

--- a/openpolicedata/deprecated/messages.py
+++ b/openpolicedata/deprecated/messages.py
@@ -1,9 +1,3 @@
-
-
-CIV_DEPRECATION_MESSAGE = "The word 'CIVILIAN' has been replaced with 'SUBJECT' in " +\
-    f"TableType names to be consistent with the Stanford Open Policing Project "+\
-    f"(https://github.com/stanford-policylab/opp/blob/master/data_readme.md). "
-
 CIV_REPLACEMENT_MESSAGE =  "{} is being corrected to {}. "+\
                     "Please replace 'CIVILIAN' with 'SUBJECT' in your code as this correction will be removed "+\
                     "in a future release."


### PR DESCRIPTION
This commit addresses #319 by:

- Removing the constants `CIV_DEPRECATION_MESSAGE` and `CIV_REPLACEMENT_MESSAGE`
- Removing checks for `"CIVILIAN"` that would print the above messages
- Removing the now empty `openpolicedata.deprecated.messages` module
- Removes the `_missing_` method on the TableType type