### PR TITLE
Remove url_contains and id_contains arguments

### DIFF
--- a/openpolicedata/data.py
+++ b/openpolicedata/data.py
@@ -801,8 +801,6 @@ class Source:
                      table_type: str | defs.TableType | None = None, 
                      year: str | int | None = None, 
                      partial_name: str | None = None,
-                     url_contains: str | None = None,
-                     id_contains: str | None = None,
                      url: str | None = None,
                      id: str | None = None
                      ) -> list[str]:
@@ -831,8 +829,6 @@ class Source:
         '''
 
         src = self.__find_datasets(table_type)
-
-        url, id = _handle_deprecated_filters(url, url_contains, id, id_contains)
 
         if url:
             src = src[src['URL'].str.contains(url, regex=False)]
@@ -890,8 +886,6 @@ class Source:
                   agency: str | None = None, 
                   force: bool = False,
                   verbose: bool | str | int = False,
-                  url_contains: str | None = None,
-                  id_contains: str | None = None,
                   url: str | None = None,
                   id: str | None = None
                   ) -> int:
@@ -928,8 +922,6 @@ class Source:
             Table object containing the requested data
         '''
 
-        url, id = _handle_deprecated_filters(url, url_contains, id, id_contains)
-
         return self.__load(table_type, year, agency, True, pbar=False, return_count=True, force=force, verbose=verbose, 
                            url_contains=url, id=id)
     
@@ -944,8 +936,6 @@ class Source:
                 sortby=None,
                 force: bool =False,
                 verbose: bool | str | int = False,
-                url_contains: str | None = None,
-                id_contains: str | None = None,
                 format_date: bool = True,
                 url: str | None = None,
                 id: str | None = None
@@ -993,8 +983,6 @@ class Source:
             generates Table objects containing the requested data
         '''
 
-        url, id = _handle_deprecated_filters(url, url_contains, id, id_contains)
-
         count = self.get_count(table_type, year, agency, force, verbose=verbose, url=url, id=id)
         for k in range(offset, count, nbatch):
             yield self.__load(table_type, year, agency, True, pbar, nrows=min(nbatch, count-k), offset=k, 
@@ -1010,8 +998,6 @@ class Source:
             offset: int = 0,
             sortby=None,
             verbose: bool | str | int = False,
-            url_contains: str | None = None,
-            id_contains: str | None = None,
             format_date: bool = True,
             url: str | None = None,
             id: str | None = None
@@ -1055,8 +1041,6 @@ class Source:
         Table
             Table object containing the requested data
         '''
-
-        url, id = _handle_deprecated_filters(url, url_contains, id, id_contains)
 
         return self.__load(table_type, year, agency, True, pbar, nrows=nrows, offset=offset, sortby=sortby, 
                            verbose=verbose, url_contains=url, id=id, format_date=format_date)
@@ -1245,8 +1229,6 @@ class Source:
                       table_type: str | defs.TableType | None = None,
                       agency: str | None = None,
                       zip: bool =False,
-                      url_contains: str | None = None,
-                      id_contains: str | None = None,
                       format_date: bool = True,
                       filename: str | None = None,
                       url: str | None = None,
@@ -1285,8 +1267,6 @@ class Source:
         Table
             Table object containing the requested data
         '''
-
-        url, id = _handle_deprecated_filters(url, url_contains, id, id_contains)
 
         table = self.__load(table_type, year, agency, False, url_contains=url, id=id, format_date=format_date)
 
@@ -1367,8 +1347,6 @@ class Source:
                          output_dir: str | None = None, 
                          table_type: str | defs.TableType | None = None,
                          agency: str | None = None,
-                         url_contains: str | None = None,
-                         id_contains: str | None = None,
                          url: str | None = None,
                          id: str | None = None
                          ) -> str:
@@ -1398,8 +1376,6 @@ class Source:
         str
             Auto-generated CSV filename
         '''
-
-        url, id = _handle_deprecated_filters(url, url_contains, id, id_contains)
 
         table = self.__load(table_type, year, agency, False, url_contains=url, id=id)
 

--- a/openpolicedata/data.py
+++ b/openpolicedata/data.py
@@ -1614,20 +1614,3 @@ def _get_years_to_check(years, cur_year, force, isfile):
         years_to_check = [x for x in range(max_year+1,cur_year+1)]
 
     return years_to_check
-
-def _handle_deprecated_filters(url, url_contains, id, id_contains):
-    if url_contains:
-        if url and url!=url_contains:
-            raise ValueError("url and url_contains cannot both be set. Please only use url, which replaces url_contains.")
-        else:
-            warnings.warn('url_contains input has been deprecated. Please replace with url.', DeprecationWarning)
-            url = url_contains
-
-    if id_contains:
-        if id and id!=id_contains:
-            raise ValueError("id and id_contains cannot both be set. Please only use id, which replaces id_contains.")
-        else:
-            warnings.warn('id_contains input has been deprecated. Please replace with id.', DeprecationWarning)
-            id = id_contains
-
-    return url, id

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -282,41 +282,6 @@ def test_datasets_iloc_warning(all_datasets, y):
 	with pytest.deprecated_call():
 		all_datasets.iloc[0,y]
 
-@pytest.mark.parametrize("x, y", [(None, 'Test'), ('Test', 'Test')])
-def test_url_contains_warning(x,y):
-	with pytest.deprecated_call():
-		result,_ = opd.data._handle_deprecated_filters(url=x, url_contains=y, id=None, id_contains=None)
-
-	assert result==y
-
-@pytest.mark.parametrize("x, y", [(None, 'Test'), ('Test', 'Test')])
-def test_id_contains_warning(x,y):
-	with pytest.deprecated_call():
-		_,result = opd.data._handle_deprecated_filters(url=None, url_contains=None, id=x, id_contains=y)
-
-	assert result==y
-
-def test_url_contains_error():
-	with pytest.raises(ValueError):
-		opd.data._handle_deprecated_filters(url='TEST', url_contains='TEST2', id=None, id_contains=None)
-
-def test_id_contains_error():
-	with pytest.raises(ValueError):
-		opd.data._handle_deprecated_filters(url=None, url_contains=None, id='TEST', id_contains='TEST2')
-
-
-def test_url_success():
-	url = 'TEST'
-	result,_ = opd.data._handle_deprecated_filters(url=url, url_contains=None, id=None, id_contains=None)
-
-	assert result==url
-
-def test_id_success():
-	id = 'TEST'
-	_, result = opd.data._handle_deprecated_filters(url=None, url_contains=None, id=id, id_contains=None)
-
-	assert result==id
-
 if __name__ == "__main__":
 	csvfile = None
 	csvfile = "C:\\Users\\matth\\repos\\opd-data\\opd_source_table.csv"


### PR DESCRIPTION
This PR removes the `url_contains` and `id_contains` arguments of all functions that also call `_handle_deprecated_filters`. It also removes the function `_handle_deprecated_filters` and any associated tests.

This addresses #321.
