### PR TITLE
Add dataset URL data type consistency tests

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -220,6 +220,20 @@ def test_arcgis_urls(datasets):
             assert result != None
             assert len(url) == result.span()[1]
 
+@pytest.mark.parametrize(
+    "url_fragment, data_type",
+    [
+        (".csv", opd.defs.DataType.CSV.value),
+        (".xls", opd.defs.DataType.EXCEL.value),
+        ("MapServer", opd.defs.DataType.ArcGIS.value),
+        ("FeatureServer", opd.defs.DataType.ArcGIS.value),
+    ],
+)
+def test_urls_match_data_type_for_obvious_fragments(datasets, url_fragment, data_type):
+    ds = datasets[datasets["URL"].str.contains(url_fragment, case=False, regex=False, na=False)]
+    assert len(ds) > 0
+    assert (ds["DataType"] == data_type).all()
+
 def test_source_list_by_state(datasets, use_changed_rows):
     state = "Virginia"
     df = opd.datasets.query(state=state)


### PR DESCRIPTION
## Summary
- add parameterized dataset checks for obvious URL fragments and matching `DataType` values
- cover CSV file URLs, Excel file URLs, and ArcGIS `MapServer` / `FeatureServer` URLs

## Validation
- `.venv/bin/python -m pytest tests/test_datasets.py::test_urls_match_data_type_for_obvious_fragments --csvfile ../opd-data/opd_source_table.csv -q`
- `.venv/bin/python -m pytest tests/test_datasets.py -k "urls_match_data_type_for_obvious_fragments or arcgis_urls" --csvfile ../opd-data/opd_source_table.csv -q`
- `git diff --check`

Note: a full local `tests/test_datasets.py` run reached the new tests but failed later in the pre-existing `test_zip` when a NYPD ZIP URL returned HTTP 403. The focused URL/DataType tests above passed.
