### PR TITLE
Support two-digit ArcGIS date years

### DIFF
--- a/openpolicedata/data_loaders/arcgis_class.py
+++ b/openpolicedata/data_loaders/arcgis_class.py
@@ -83,6 +83,7 @@ class Arcgis(Data_Loader):
 
         self._date_type = None
         self._date_format = None
+        self._year_digits = 4
         self.date_field = date_field
         self.query = str2json(query)
 
@@ -320,6 +321,7 @@ class Arcgis(Data_Loader):
                 ineq_comp: bool = False
                 date_delim: str = ""
                 full_date: bool = True
+                year_digits: int = 4
 
             matches = [
                 DateParseParams(re.compile(r"^(19|20)\d{6}\b"), ineq_comp=True),  # YYYYMMDD
@@ -329,6 +331,12 @@ class Arcgis(Data_Loader):
                 DateParseParams(re.compile(r"^[A-Z][a-z]+ \d{1,2}, (19|20)\d{2}\b"), "{} LIKE '[A-Z]% [0-9][0-9], {}' OR {} LIKE '[A-Z]% [0-9], {}'"),  # Month DD, YYYY
                 DateParseParams(re.compile(r"^\d{1,2}[-/]\d{1,2}[-/](19|20)\d{2}\b"), 
                     "{} LIKE '%[/-]{}%'"),  # mm/dd/yyyy or mm-dd-yyyy
+                DateParseParams(re.compile(r"^\d{1,2}[-/]\d{1,2}[-/]\d{2}\b"),
+                    "{} LIKE '_/_/{} %' OR {} LIKE '__/_/{} %' OR {} LIKE '_/__/{} %' OR {} LIKE '__/__/{} %' OR "
+                    "{} LIKE '_-_-{} %' OR {} LIKE '__-_-{} %' OR {} LIKE '_-__-{} %' OR {} LIKE '__-__-{} %' OR "
+                    "{} LIKE '_/_/{}' OR {} LIKE '__/_/{}' OR {} LIKE '_/__/{}' OR {} LIKE '__/__/{}' OR "
+                    "{} LIKE '_-_-{}' OR {} LIKE '__-_-{}' OR {} LIKE '_-__-{}' OR {} LIKE '__-__-{}'",
+                    year_digits=2),  # mm/dd/yy or mm-dd-yy
                 DateParseParams(re.compile(r"^\d{4}[-/]\d{1,2}$"), "{} LIKE '{}[-/]%'", full_date=False),  # YYYY-MM or YYYY/M
                 DateParseParams(re.compile(r"^\d{4}$"), "{} = '{}'", full_date=False),  # YYYY
                 DateParseParams(re.compile(r"^\d{1,2}[-/]\d{4}$"), "{} LIKE '[0-9][0-9][-/]{}' OR {} LIKE '[0-9][-/]{}'", full_date=False),  # MM-YYYY or MM/YYYY
@@ -350,6 +358,7 @@ class Arcgis(Data_Loader):
             else:
                 self._date_format = repeat_format(matches[idx].arcgis_pattern)
                 self._full_date = matches[idx].full_date
+                self._year_digits = matches[idx].year_digits
 
         if self._ineq_comp:
             where_query, record_count = self._build_date_query_date_type(date, self._date_delim, is_date_string=True)
@@ -363,10 +372,14 @@ class Arcgis(Data_Loader):
                 raise ValueError(f"Date column is a string data type at the source {self.url}. "+
                                 "Currently only able to filter for a single year (2023) or a year range ([2022,2023]) "+
                                 "not a date range ([2022-01-01, 2022-03-01]).")
+
+            def format_year(year):
+                year = str(year)
+                return year[-2:] if self._year_digits == 2 else year
             
-            where_query = self._date_format.format(self.date_field, date[0])
+            where_query = self._date_format.format(self.date_field, format_year(date[0]))
             for x in range(int(date[0])+1,int(date[1])+1):
-                where_query = f"{where_query} or " + self._date_format.format(self.date_field, x)
+                where_query = f"{where_query} or " + self._date_format.format(self.date_field, format_year(x))
 
             record_count = self.__request(where=where_query, return_count=True)["count"]
 

--- a/tests/test_loader_arcgis.py
+++ b/tests/test_loader_arcgis.py
@@ -147,6 +147,43 @@ def test_arcgis_text_date(url, year, date_field):
     else:
         assert all([x in un_months for x in range(1,13)])
 
+
+def test_arcgis_two_digit_year_text_date_query(monkeypatch):
+    url = "https://example.com/arcgis/rest/services/Test/FeatureServer/0"
+    loader = data_loaders.Arcgis.__new__(data_loaders.Arcgis)
+    loader.url = url
+    loader.date_field = "DATE_REPORTED"
+    loader.query = {}
+    loader._date_type = None
+    loader._date_format = None
+    loader._year_digits = 4
+    loader._last_count = None
+
+    sample_data = {
+        "fields": [{"name": "DATE_REPORTED", "type": "esriFieldTypeString"}],
+        "features": [
+            {"attributes": {"DATE_REPORTED": "1/1/18 1:00 AM"}},
+            {"attributes": {"DATE_REPORTED": "12/31/18 11:59 PM"}},
+        ],
+    }
+    queries = []
+
+    def request_stub(where=None, return_count=False, **kwargs):
+        if where == "DATE_REPORTED IS NOT NULL":
+            return sample_data
+        queries.append(where)
+        return {"count": 2}
+
+    monkeypatch.setattr(loader, "_Arcgis__request", request_stub)
+
+    where_query, record_count = loader._build_date_query([pd.Timestamp("2018-01-01"), pd.Timestamp("2018-12-31")], True)
+
+    assert record_count == 2
+    assert queries == [where_query]
+    assert "DATE_REPORTED LIKE '_/_/18 %'" in where_query
+    assert "DATE_REPORTED LIKE '__/__/18'" in where_query
+    assert "2018" not in where_query
+
 def test_arcgis_query():
     url = 'https://services1.arcgis.com/JLuzSHjNrLL4Okwb/arcgis/rest/services/Gilbert_Demographics/FeatureServer/0'
 


### PR DESCRIPTION
Addresses openpolicedata/openpolicedata#359

- Adds ArcGIS string-date detection for `M/D/YY` / `MM/DD/YY` style date values.
- Builds year-based ArcGIS `LIKE` filters using two-digit year suffixes while keeping non-year date ranges guarded by the existing inaccurate-query fallback behavior.
- Adds a focused unit test for the generated two-digit-year query.

This allows the annual Louisville 2003-2018 ArcGIS incident rows in `opd-data` to be validated with `DATE_REPORTED`.

Checks:
- `python -m pytest tests/test_loader_arcgis.py::test_arcgis_two_digit_year_text_date_query tests/test_defs.py tests/test_utils.py -q` (`3 passed`)
- Louisville 2003-2018 annual ArcGIS loader validation with `DATE_REPORTED` (`16 passed`, `0 failed`)
- `git diff --check`